### PR TITLE
Switches project license to AGPLv3

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,8 @@
+Ratot
+Copyright (C) 2026 Captain Ratax
+
+This project is licensed under the GNU Affero General Public License v3.0 or later.
+See the LICENSE file for the full license text.
+
+Source code repository:
+https://github.com/Ratot-Team/Ratot

--- a/LICENSE
+++ b/LICENSE
@@ -1,190 +1,178 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
                             Preamble
 
-The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works. By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users. We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors. You can apply it to
-your programs, too.
+software for all its users.
 
-When we speak of free software, we are referring to freedom, not
-price. Our General Public Licenses are designed to make sure that you
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights. Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received. You must make sure that they, too, receive
-or can get the source code. And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software. For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so. This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software. The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable. Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products. If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary. To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
-
-The precise terms and conditions for copying, distribution and
+  The precise terms and conditions for copying, distribution and
 modification follow.
 
                        TERMS AND CONDITIONS
 
-0. Definitions.
+  0. Definitions.
 
-"This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-"Copyright" also means copyright-like laws that apply to other kinds of
+  "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
 
-"The Program" refers to any copyrightable work licensed under this
-License. Each licensee is addressed as "you". "Licensees" and
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
 "recipients" may be individuals or organizations.
 
-To "modify" a work means to copy from or adapt all or part of the work
+  To "modify" a work means to copy from or adapt all or part of the work
 in a fashion requiring copyright permission, other than the making of an
-exact copy. The resulting work is called a "modified version" of the
+exact copy.  The resulting work is called a "modified version" of the
 earlier work or a work "based on" the earlier work.
 
-A "covered work" means either the unmodified Program or a work based
+  A "covered work" means either the unmodified Program or a work based
 on the Program.
 
-To "propagate" a work means to do anything with it that, without
+  To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy. Propagation includes copying,
+computer or modifying a private copy.  Propagation includes copying,
 distribution (with or without modification), making available to the
 public, and in some countries other activities as well.
 
-To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies. Mere interaction with a user through
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
 a computer network, with no transfer of a copy, is not conveying.
 
-An interactive user interface displays "Appropriate Legal Notices"
+  An interactive user interface displays "Appropriate Legal Notices"
 to the extent that it includes a convenient and prominently visible
 feature that (1) displays an appropriate copyright notice, and (2)
 tells the user that there is no warranty for the work (except to the
 extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License. If
+work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
 menu, a prominent item in the list meets this criterion.
 
-1. Source Code.
+  1. Source Code.
 
-The "source code" for a work means the preferred form of the work
-for making modifications to it. "Object code" means any non-source
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
 form of a work.
 
-A "Standard Interface" means an interface that either is an official
+  A "Standard Interface" means an interface that either is an official
 standard defined by a recognized standards body, or, in the case of
 interfaces specified for a particular programming language, one that
 is widely used among developers working in that language.
 
-The "System Libraries" of an executable work include anything, other
+  The "System Libraries" of an executable work include anything, other
 than the work as a whole, that (a) is included in the normal form of
 packaging a Major Component, but which is not part of that Major
 Component, and (b) serves only to enable use of the work with that
 Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form. A
+implementation is available to the public in source code form.  A
 "Major Component", in this context, means a major essential component
 (kernel, window system, and so on) of the specific operating system
 (if any) on which the executable work runs, or a compiler used to
 produce the work, or an object code interpreter used to run it.
 
-The "Corresponding Source" for a work in object code form means all
+  The "Corresponding Source" for a work in object code form means all
 the source code needed to generate, install, and (for an executable
 work) run the object code and to modify the work, including scripts to
-control those activities. However, it does not include the work's
+control those activities.  However, it does not include the work's
 System Libraries, or general-purpose tools or generally available free
 programs which are used unmodified in performing those activities but
-which are not part of the work. For example, Corresponding Source
+which are not part of the work.  For example, Corresponding Source
 includes interface definition files associated with source files for
 the work, and the source code for shared libraries and dynamically
 linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
 subprograms and other parts of the work.
 
-The Corresponding Source need not include anything that users
+  The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
 Source.
 
-The Corresponding Source for a work in source code form is that
+  The Corresponding Source for a work in source code form is that
 same work.
 
-2. Basic Permissions.
+  2. Basic Permissions.
 
-All rights granted under this License are granted for the term of
+  All rights granted under this License are granted for the term of
 copyright on the Program, and are irrevocable provided the stated
-conditions are met. This License explicitly affirms your unlimited
-permission to run the unmodified Program. The output from running a
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
 covered work is covered by this License only if the output, given its
-content, constitutes a covered work. This License acknowledges your
+content, constitutes a covered work.  This License acknowledges your
 rights of fair use or other equivalent, as provided by copyright law.
 
-You may make, run and propagate covered works that you do not
+  You may make, run and propagate covered works that you do not
 convey, without conditions so long as your license otherwise remains
-in force. You may convey covered works to others for the sole purpose
+in force.  You may convey covered works to others for the sole purpose
 of having them make modifications exclusively for you, or provide you
 with facilities for running those works, provided that you comply with
 the terms of this License in conveying all material for which you do
-not control copyright. Those thus making or running the covered works
+not control copyright.  Those thus making or running the covered works
 for you must do so exclusively on your behalf, under your direction
 and control, on terms that prohibit them from making any copies of
 your copyrighted material outside their relationship with you.
 
-Conveying under any other circumstances is permitted solely under
-the conditions stated below. Sublicensing is not allowed; section 10
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
 makes it unnecessary.
 
-3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-No covered work shall be deemed part of an effective technological
+  No covered work shall be deemed part of an effective technological
 measure under any applicable law fulfilling obligations under article
 11 of the WIPO copyright treaty adopted on 20 December 1996, or
 similar laws prohibiting or restricting circumvention of such
 measures.
 
-When you convey a covered work, you waive any legal power to forbid
+  When you convey a covered work, you waive any legal power to forbid
 circumvention of technological measures to the extent such circumvention
 is effected by exercising rights under this License with respect to
 the covered work, and you disclaim any intention to limit operation or
@@ -192,9 +180,9 @@ modification of the work as a means of enforcing, against the work's
 users, your or third parties' legal rights to forbid circumvention of
 technological measures.
 
-4. Conveying Verbatim Copies.
+  4. Conveying Verbatim Copies.
 
-You may convey verbatim copies of the Program's source code as you
+  You may convey verbatim copies of the Program's source code as you
 receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
 keep intact all notices stating that this License and any
@@ -202,12 +190,12 @@ non-permissive terms added in accord with section 7 apply to the code;
 keep intact all notices of the absence of any warranty; and give all
 recipients a copy of this License along with the Program.
 
-You may charge any price or no price for each copy that you convey,
+  You may charge any price or no price for each copy that you convey,
 and you may offer support or warranty protection for a fee.
 
-5. Conveying Modified Source Versions.
+  5. Conveying Modified Source Versions.
 
-You may convey a work based on the Program, or the modifications to
+  You may convey a work based on the Program, or the modifications to
 produce it from the Program, in the form of source code under the
 terms of section 4, provided that you also meet all of these conditions:
 
@@ -232,19 +220,19 @@ terms of section 4, provided that you also meet all of these conditions:
     interfaces that do not display Appropriate Legal Notices, your
     work need not make them do so.
 
-A compilation of a covered work with other separate and independent
+  A compilation of a covered work with other separate and independent
 works, which are not by their nature extensions of the covered work,
 and which are not combined with it such as to form a larger program,
 in or on a volume of a storage or distribution medium, is called an
 "aggregate" if the compilation and its resulting copyright are not
 used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit. Inclusion of a covered work
+beyond what the individual works permit.  Inclusion of a covered work
 in an aggregate does not cause this License to apply to the other
 parts of the aggregate.
 
-6. Conveying Non-Source Forms.
+  6. Conveying Non-Source Forms.
 
-You may convey a covered work in object code form under the terms
+  You may convey a covered work in object code form under the terms
 of sections 4 and 5, provided that you also convey the
 machine-readable Corresponding Source under the terms of this License,
 in one of these ways:
@@ -290,75 +278,75 @@ in one of these ways:
     Source of the work are being offered to the general public at no
     charge under subsection 6d.
 
-A separable portion of the object code, whose source code is excluded
+  A separable portion of the object code, whose source code is excluded
 from the Corresponding Source as a System Library, need not be
 included in conveying the object code work.
 
-A "User Product" is either (1) a "consumer product", which means any
+  A "User Product" is either (1) a "consumer product", which means any
 tangible personal property which is normally used for personal, family,
 or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling. In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage. For a particular
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
 product received by a particular user, "normally used" refers to a
 typical or common use of that class of product, regardless of the status
 of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product. A product
+actually uses, or expects or is expected to use, the product.  A product
 is a consumer product regardless of whether the product has substantial
 commercial, industrial or non-consumer uses, unless such uses represent
 the only significant mode of use of the product.
 
-"Installation Information" for a User Product means any methods,
+  "Installation Information" for a User Product means any methods,
 procedures, authorization keys, or other information required to install
 and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source. The information must
+a modified version of its Corresponding Source.  The information must
 suffice to ensure that the continued functioning of the modified object
 code is in no case prevented or interfered with solely because
 modification has been made.
 
-If you convey an object code work under this section in, or with, or
+  If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
 part of a transaction in which the right of possession and use of the
 User Product is transferred to the recipient in perpetuity or for a
 fixed term (regardless of how the transaction is characterized), the
 Corresponding Source conveyed under this section must be accompanied
-by the Installation Information. But this requirement does not apply
+by the Installation Information.  But this requirement does not apply
 if neither you nor any third party retains the ability to install
 modified object code on the User Product (for example, the work has
 been installed in ROM).
 
-The requirement to provide Installation Information does not include a
+  The requirement to provide Installation Information does not include a
 requirement to continue to provide support service, warranty, or updates
 for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed. Access to a
+the User Product in which it has been modified or installed.  Access to a
 network may be denied when the modification itself materially and
 adversely affects the operation of the network or violates the rules and
 protocols for communication across the network.
 
-Corresponding Source conveyed, and Installation Information provided,
+  Corresponding Source conveyed, and Installation Information provided,
 in accord with this section must be in a format that is publicly
 documented (and with an implementation available to the public in
 source code form), and must require no special password or key for
 unpacking, reading or copying.
 
-7. Additional Terms.
+  7. Additional Terms.
 
-"Additional permissions" are terms that supplement the terms of this
+  "Additional permissions" are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions.
 Additional permissions that are applicable to the entire Program shall
 be treated as though they were included in this License, to the extent
-that they are valid under applicable law. If additional permissions
+that they are valid under applicable law.  If additional permissions
 apply only to part of the Program, that part may be used separately
 under those permissions, but the entire Program remains governed by
 this License without regard to the additional permissions.
 
-When you convey a copy of a covered work, you may at your option
+  When you convey a copy of a covered work, you may at your option
 remove any additional permissions from that copy, or from any part of
-it. (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.) You may place
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
 for which you have or can give appropriate copyright permission.
 
-Notwithstanding any other provision of this License, for material you
+  Notwithstanding any other provision of this License, for material you
 add to a covered work, you may (if authorized by the copyright holders of
 that material) supplement the terms of this License with terms:
 
@@ -385,74 +373,74 @@ that material) supplement the terms of this License with terms:
     any liability that these contractual assumptions directly impose on
     those licensors and authors.
 
-All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10. If the Program as you
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
 received it, or any part of it, contains a notice stating that it is
 governed by this License along with a term that is a further
-restriction, you may remove that term. If a license document contains
+restriction, you may remove that term.  If a license document contains
 a further restriction but permits relicensing or conveying under this
 License, you may add to a covered work material governed by the terms
 of that license document, provided that the further restriction does
 not survive such relicensing or conveying.
 
-If you add terms to a covered work in accord with this section, you
+  If you add terms to a covered work in accord with this section, you
 must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
 where to find the applicable terms.
 
-Additional terms, permissive or non-permissive, may be stated in the
+  Additional terms, permissive or non-permissive, may be stated in the
 form of a separately written license, or stated as exceptions;
 the above requirements apply either way.
 
-8. Termination.
+  8. Termination.
 
-You may not propagate or modify a covered work except as expressly
-provided under this License. Any attempt otherwise to propagate or
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
 modify it is void, and will automatically terminate your rights under
 this License (including any patent licenses granted under the third
 paragraph of section 11).
 
-However, if you cease all violation of this License, then your
+  However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
 finally terminates your license, and (b) permanently, if the copyright
 holder fails to notify you of the violation by some reasonable means
 prior to 60 days after the cessation.
 
-Moreover, your license from a particular copyright holder is
+  Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
 your receipt of the notice.
 
-Termination of your rights under this section does not terminate the
+  Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
-this License. If your rights have been terminated and not permanently
+this License.  If your rights have been terminated and not permanently
 reinstated, you do not qualify to receive new licenses for the same
 material under section 10.
 
-9. Acceptance Not Required for Having Copies.
+  9. Acceptance Not Required for Having Copies.
 
-You are not required to accept this License in order to receive or
-run a copy of the Program. Ancillary propagation of a covered work
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
 occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance. However,
+to receive a copy likewise does not require acceptance.  However,
 nothing other than this License grants you permission to propagate or
-modify any covered work. These actions infringe copyright if you do
-not accept this License. Therefore, by modifying or propagating a
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
 covered work, you indicate your acceptance of this License to do so.
 
-10. Automatic Licensing of Downstream Recipients.
+  10. Automatic Licensing of Downstream Recipients.
 
-Each time you convey a covered work, the recipient automatically
+  Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License. You are not responsible
+propagate that work, subject to this License.  You are not responsible
 for enforcing compliance by third parties with this License.
 
-An "entity transaction" is a transaction transferring control of an
+  An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations. If propagation of a covered
+organization, or merging organizations.  If propagation of a covered
 work results from an entity transaction, each party to that
 transaction who receives a copy of the work also receives whatever
 licenses to the work the party's predecessor in interest had or could
@@ -460,43 +448,43 @@ give under the previous paragraph, plus a right to possession of the
 Corresponding Source of the work from the predecessor in interest, if
 the predecessor has it or can get it with reasonable efforts.
 
-You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License. For example, you may
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
 not impose a license fee, royalty, or other charge for exercise of
 rights granted under this License, and you may not initiate litigation
 (including a cross-claim or counterclaim in a lawsuit) alleging that
 any patent claim is infringed by making, using, selling, offering for
 sale, or importing the Program or any portion of it.
 
-11. Patents.
+  11. Patents.
 
-A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based. The
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
 work thus licensed is called the contributor's "contributor version".
 
-A contributor's "essential patent claims" are all patent claims
+  A contributor's "essential patent claims" are all patent claims
 owned or controlled by the contributor, whether already acquired or
 hereafter acquired, that would be infringed by some manner, permitted
 by this License, of making, using, or selling its contributor version,
 but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version. For
+consequence of further modification of the contributor version.  For
 purposes of this definition, "control" includes the right to grant
 patent sublicenses in a manner consistent with the requirements of
 this License.
 
-Each contributor grants you a non-exclusive, worldwide, royalty-free
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
 patent license under the contributor's essential patent claims, to
 make, use, sell, offer for sale, import and otherwise run, modify and
 propagate the contents of its contributor version.
 
-In the following three paragraphs, a "patent license" is any express
+  In the following three paragraphs, a "patent license" is any express
 agreement or commitment, however denominated, not to enforce a patent
 (such as an express permission to practice a patent or covenant not to
-sue for patent infringement). To "grant" such a patent license to a
+sue for patent infringement).  To "grant" such a patent license to a
 party means to make such an agreement or commitment not to enforce a
 patent against the party.
 
-If you convey a covered work, knowingly relying on a patent license,
+  If you convey a covered work, knowingly relying on a patent license,
 and the Corresponding Source of the work is not available for anyone
 to copy, free of charge and under the terms of this License, through a
 publicly available network server or other readily accessible means,
@@ -504,13 +492,13 @@ then you must either (1) cause the Corresponding Source to be so
 available, or (2) arrange to deprive yourself of the benefit of the
 patent license for this particular work, or (3) arrange, in a manner
 consistent with the requirements of this License, to extend the patent
-license to downstream recipients. "Knowingly relying" means you have
+license to downstream recipients.  "Knowingly relying" means you have
 actual knowledge that, but for the patent license, your conveying the
 covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
 country that you have reason to believe are valid.
 
-If, pursuant to or in connection with a single transaction or
+  If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
 receiving the covered work authorizing them to use, propagate, modify
@@ -518,10 +506,10 @@ or convey a specific copy of the covered work, then the patent license
 you grant is automatically extended to all recipients of the covered
 work and works based on it.
 
-A patent license is "discriminatory" if it does not include within
+  A patent license is "discriminatory" if it does not include within
 the scope of its coverage, prohibits the exercise of, or is
 conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License. You may not convey a covered
+specifically granted under this License.  You may not convey a covered
 work if you are a party to an arrangement with a third party that is
 in the business of distributing software, under which you make payment
 to the third party based on the extent of your activity of conveying
@@ -533,73 +521,83 @@ for and in connection with specific products or compilations that
 contain the covered work, unless you entered into that arrangement,
 or that patent license was granted, prior to 28 March 2007.
 
-Nothing in this License shall be construed as excluding or limiting
+  Nothing in this License shall be construed as excluding or limiting
 any implied license or other defenses to infringement that may
 otherwise be available to you under applicable patent law.
 
-12. No Surrender of Others' Freedom.
+  12. No Surrender of Others' Freedom.
 
-If conditions are imposed on you (whether by court order, agreement or
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License. If you cannot convey a
+excuse you from the conditions of this License.  If you cannot convey a
 covered work so as to satisfy simultaneously your obligations under this
 License and any other pertinent obligations, then as a consequence you may
-not convey it at all. For example, if you agree to terms that obligate you
+not convey it at all.  For example, if you agree to terms that obligate you
 to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
 
-Notwithstanding any other provision of this License, you have
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
-combined work, and to convey the resulting work. The terms of this
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
-14. Revised Versions of this License.
+  14. Revised Versions of this License.
 
-The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time. Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number. If the
-Program specifies that a certain numbered version of the GNU General
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
-Foundation. If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
-If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
-Later license versions may give you additional or different
-permissions. However, no additional obligations are imposed on any
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
 later version.
 
-15. Disclaimer of Warranty.
+  15. Disclaimer of Warranty.
 
-THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
 HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
 OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
 THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
 ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-16. Limitation of Liability.
+  16. Limitation of Liability.
 
-IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
 GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -609,9 +607,9 @@ PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGES.
 
-17. Interpretation of Sections 15 and 16.
+  17. Interpretation of Sections 15 and 16.
 
-If the disclaimer of warranty and limitation of liability provided
+  If the disclaimer of warranty and limitation of liability provided
 above cannot be given local legal effect according to their terms,
 reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
@@ -622,54 +620,42 @@ copy of the Program in return for a fee.
 
             How to Apply These Terms to Your New Programs
 
-If you develop a new program, and you want it to be of the greatest
+  If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
 free software which everyone can redistribute and change under these terms.
 
-To do so, attach the following notices to the program. It is safest
+  To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Ratot is a Discord bot made to help you administrate your server and
-    have some fun.
-    Copyright (C) 2020-2024  Captain Ratax
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
-    Ratot  Copyright (C) 2020-2024  Captain Ratax
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License. Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
-
-You should also get your employer (if you work as a programmer) or school,
+  You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
+For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
-
-The GNU General Public License does not permit incorporating your program
-into proprietary programs. If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library. If this is what you want to do, use the GNU Lesser General
-Public License instead of this License. But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -91,4 +91,11 @@ Lists all the channels from a given server ID or from the server where the messa
 
 ## License
 
-[GPLv3](https://github.com/Ratot-Team/Ratot/blob/master/LICENSE)
+Copyright (C) 2026 Captain Ratax
+
+This project is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+See the [LICENSE](./LICENSE) file for the full license text.

--- a/models/botAdminsSchema.js
+++ b/models/botAdminsSchema.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 var mongoose = require("mongoose");
 
 const botAdminsSchema = new mongoose.Schema(

--- a/models/botConfigsLogSchema.js
+++ b/models/botConfigsLogSchema.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 var mongoose = require("mongoose");
 
 const botConfigsLogSchema = new mongoose.Schema(

--- a/models/botConfigsSchema.js
+++ b/models/botConfigsSchema.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 var mongoose = require("mongoose");
 
 const botConfigsSchema = new mongoose.Schema(

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,27 +11,29 @@
 			"dependencies": {
 				"discord.js": "^14.25.1",
 				"dotenv": "^17.3.1",
-				"express": "^4.22.0",
-				"mongoose": "^9.2.1",
-				"node": "^19.8.1",
-				"winston": "^3.11.0",
-				"winston-daily-rotate-file": "^4.7.1"
+				"express": "^5.2.1",
+				"mongoose": "^9.3.1",
+				"node": "^25.8.1",
+				"winston": "^3.19.0",
+				"winston-daily-rotate-file": "^5.0.0"
 			}
 		},
 		"node_modules/@colors/colors": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
 			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.1.90"
 			}
 		},
 		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+			"integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+			"license": "MIT",
 			"dependencies": {
-				"colorspace": "1.1.x",
+				"@so-ric/colorspace": "^1.1.6",
 				"enabled": "2.0.x",
 				"kuler": "^2.0.0"
 			}
@@ -61,6 +63,7 @@
 			"version": "1.5.3",
 			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
 			"integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.11.0"
 			}
@@ -207,18 +210,30 @@
 				"npm": ">=7.0.0"
 			}
 		},
-		"node_modules/@types/node": {
-			"version": "20.12.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-			"integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+		"node_modules/@so-ric/colorspace": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+			"integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"color": "^5.0.2",
+				"text-hex": "1.0.x"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/@types/triple-beam": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+			"license": "MIT"
 		},
 		"node_modules/@types/webidl-conversions": {
 			"version": "7.0.3",
@@ -255,49 +270,46 @@
 			}
 		},
 		"node_modules/accepts": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
 			"dependencies": {
-				"mime-types": "~2.1.34",
-				"negotiator": "0.6.3"
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-		},
 		"node_modules/async": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"license": "MIT"
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.4",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
 			"license": "MIT",
 			"dependencies": {
-				"bytes": "~3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "~1.2.0",
-				"http-errors": "~2.0.1",
-				"iconv-lite": "~0.4.24",
-				"on-finished": "~2.4.1",
-				"qs": "~6.14.0",
-				"raw-body": "~2.5.3",
-				"type-is": "~1.6.18",
-				"unpipe": "~1.0.0"
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
 			},
 			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/bson": {
@@ -348,54 +360,62 @@
 			}
 		},
 		"node_modules/color": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+			"license": "MIT",
 			"dependencies": {
-				"color-convert": "^1.9.3",
-				"color-string": "^1.6.0"
+				"color-convert": "^3.1.3",
+				"color-string": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+			"license": "MIT",
 			"dependencies": {
-				"color-name": "1.1.3"
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.6"
 			}
 		},
 		"node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20"
 			}
 		},
-		"node_modules/colorspace": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+		"node_modules/color-string": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+			"license": "MIT",
 			"dependencies": {
-				"color": "^3.1.3",
-				"text-hex": "1.0.x"
+				"color-name": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/content-disposition": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+			"integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/content-type": {
@@ -417,17 +437,29 @@
 			}
 		},
 		"node_modules/cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
 		},
 		"node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"license": "MIT",
 			"dependencies": {
-				"ms": "2.0.0"
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/depd": {
@@ -439,20 +471,10 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/destroy": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
 		"node_modules/discord-api-types": {
-			"version": "0.38.38",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.38.tgz",
-			"integrity": "sha512-7qcM5IeZrfb+LXW07HvoI5L+j4PQeMZXEkSm1htHAHh4Y9JSMXBWjy/r7zmUCOj4F7zNjMcm7IMWr131MT2h0Q==",
+			"version": "0.38.42",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz",
+			"integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==",
 			"license": "MIT",
 			"workspaces": [
 				"scripts/actions/documentation"
@@ -520,7 +542,8 @@
 		"node_modules/enabled": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+			"license": "MIT"
 		},
 		"node_modules/encodeurl": {
 			"version": "2.0.0",
@@ -577,45 +600,42 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
 			},
 			"engines": {
-				"node": ">= 0.10.0"
+				"node": ">= 18"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -631,54 +651,61 @@
 		"node_modules/fecha": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+			"license": "MIT"
 		},
 		"node_modules/file-stream-rotator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
 			"integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+			"license": "MIT",
 			"dependencies": {
 				"moment": "^2.29.1"
 			}
 		},
 		"node_modules/finalhandler": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-			"integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "2.6.9",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"statuses": "~2.0.2",
-				"unpipe": "~1.0.0"
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
 			},
 			"engines": {
-				"node": ">= 0.8"
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/fn.name": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+			"license": "MIT"
 		},
 		"node_modules/forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
 			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/function-bind": {
@@ -784,39 +811,47 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"license": "MIT",
 			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -836,7 +871,8 @@
 		"node_modules/kuler": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"license": "MIT"
 		},
 		"node_modules/lodash": {
 			"version": "4.17.23",
@@ -847,12 +883,14 @@
 		"node_modules/lodash.snakecase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+			"license": "MIT"
 		},
 		"node_modules/logform": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "1.6.0",
 				"@types/triple-beam": "^1.3.2",
@@ -864,11 +902,6 @@
 			"engines": {
 				"node": ">= 12.0.0"
 			}
-		},
-		"node_modules/logform/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/magic-bytes.js": {
 			"version": "1.13.0",
@@ -886,12 +919,12 @@
 			}
 		},
 		"node_modules/media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/memory-pager": {
@@ -901,69 +934,59 @@
 			"license": "MIT"
 		},
 		"node_modules/merge-descriptors": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-			"integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
 			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
 			"dependencies": {
-				"mime-db": "1.52.0"
+				"mime-db": "^1.54.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/moment": {
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
 			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/mongodb": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz",
-			"integrity": "sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
+			"integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.3.0",
-				"bson": "^7.0.0",
+				"bson": "^7.1.1",
 				"mongodb-connection-string-url": "^7.0.0"
 			},
 			"engines": {
@@ -1016,13 +1039,13 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.2.1.tgz",
-			"integrity": "sha512-fmNLwgct5km7iL1MqvTMncarR1E1TIw2lmc9A4UoDVdS7AQe95K+DnRK0qATkSUdwUC9V/5wlDcqnkQQjbSRkA==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.1.tgz",
+			"integrity": "sha512-58DuQti+LlRS74/UfWN4F3wZsC0Yr1dgTWZ2Wd3/TuSvm6rIdyAjDWbx2xGyuBooqJYdAWotVv4mQgVdivh+3Q==",
 			"license": "MIT",
 			"dependencies": {
 				"kareem": "3.2.0",
-				"mongodb": "~7.0",
+				"mongodb": "~7.1",
 				"mpath": "0.9.0",
 				"mquery": "6.0.0",
 				"ms": "2.1.3",
@@ -1036,15 +1059,11 @@
 				"url": "https://opencollective.com/mongoose"
 			}
 		},
-		"node_modules/mongoose/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-		},
 		"node_modules/mpath": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
 			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -1059,24 +1078,26 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
 		"node_modules/negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/node": {
-			"version": "19.8.1",
-			"resolved": "https://registry.npmjs.org/node/-/node-19.8.1.tgz",
-			"integrity": "sha512-qAoX6xM9F/eEv4q4qgCXGSbXWruHVzVJX32XCZizSUNsg5ywYY7di9QMqSDFmPwvJrXjZuhNq2z80+lR9GumLg==",
+			"version": "25.8.1",
+			"resolved": "https://registry.npmjs.org/node/-/node-25.8.1.tgz",
+			"integrity": "sha512-AG1iDDN7Uzku6rFQTjfrqZZRjur8YPkO73PnfDfoj5348DQmFACA8D4X8EhvO8ObIntENK5e/aVviy+sFsAbOA==",
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
 				"node-bin-setup": "^1.0.0"
 			},
@@ -1088,14 +1109,16 @@
 			}
 		},
 		"node_modules/node-bin-setup": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
-			"integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.4.tgz",
+			"integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA==",
+			"license": "ISC"
 		},
 		"node_modules/object-hash": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -1124,10 +1147,20 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
 		"node_modules/one-time": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
 			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+			"license": "MIT",
 			"dependencies": {
 				"fn.name": "1.x.x"
 			}
@@ -1142,15 +1175,20 @@
 			}
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-			"license": "MIT"
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
 			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
 			"dependencies": {
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
@@ -1169,9 +1207,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -1193,24 +1231,25 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "~3.1.2",
 				"http-errors": "~2.0.1",
-				"iconv-lite": "~0.4.24",
+				"iconv-lite": "~0.7.0",
 				"unpipe": "~1.0.0"
 			},
 			"engines": {
-				"node": ">= 0.8"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -1218,6 +1257,22 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -1237,12 +1292,14 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -1254,48 +1311,48 @@
 			"license": "MIT"
 		},
 		"node_modules/send": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
 			"license": "MIT",
 			"dependencies": {
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.1",
-				"mime": "1.6.0",
-				"ms": "2.1.3",
-				"on-finished": "~2.4.1",
-				"range-parser": "~1.2.1",
-				"statuses": "~2.0.2"
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
 			},
 			"engines": {
-				"node": ">= 0.8.0"
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/send/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"license": "MIT"
-		},
 		"node_modules/serve-static": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
 			"license": "MIT",
 			"dependencies": {
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "~0.19.1"
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
 			},
 			"engines": {
-				"node": ">= 0.8.0"
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/setprototypeof": {
@@ -1382,14 +1439,6 @@
 			"integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
 			"license": "MIT"
 		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
-			}
-		},
 		"node_modules/sparse-bitfield": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -1403,6 +1452,7 @@
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
 			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
@@ -1420,6 +1470,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -1427,7 +1478,8 @@
 		"node_modules/text-hex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+			"license": "MIT"
 		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
@@ -1454,6 +1506,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
 			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 14.0.0"
 			}
@@ -1471,31 +1524,33 @@
 			"license": "0BSD"
 		},
 		"node_modules/type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
 			"license": "MIT",
 			"dependencies": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+			"integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"license": "MIT"
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
@@ -1509,20 +1564,14 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-		},
-		"node_modules/utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
 		},
 		"node_modules/vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -1550,35 +1599,37 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
-			"integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "^1.6.0",
-				"@dabh/diagnostics": "^2.0.2",
+				"@dabh/diagnostics": "^2.0.8",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
+				"logform": "^2.7.0",
 				"one-time": "^1.0.0",
 				"readable-stream": "^3.4.0",
 				"safe-stable-stringify": "^2.3.1",
 				"stack-trace": "0.0.x",
 				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.7.0"
+				"winston-transport": "^4.9.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/winston-daily-rotate-file": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz",
-			"integrity": "sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+			"integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+			"license": "MIT",
 			"dependencies": {
 				"file-stream-rotator": "^0.6.1",
-				"object-hash": "^2.0.1",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.4.0"
+				"object-hash": "^3.0.0",
+				"triple-beam": "^1.4.1",
+				"winston-transport": "^4.7.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -1588,17 +1639,24 @@
 			}
 		},
 		"node_modules/winston-transport": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
-			"integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+			"license": "MIT",
 			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
+				"logform": "^2.7.0",
+				"readable-stream": "^3.6.2",
 				"triple-beam": "^1.3.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
 			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
 		},
 		"node_modules/ws": {
 			"version": "8.19.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "git+https://github.com/Ratot-Team/Ratot.git"
 	},
 	"author": "Captain Ratax",
-	"license": "GPL-3.0",
+	"license": "AGPLv3",
 	"bugs": {
 		"url": "https://github.com/Ratot-Team/Ratot/issues"
 	},
@@ -20,11 +20,11 @@
 	"dependencies": {
 		"discord.js": "^14.25.1",
 		"dotenv": "^17.3.1",
-		"express": "^4.22.0",
-		"mongoose": "^9.2.1",
-		"node": "^19.8.1",
-		"winston": "^3.11.0",
-		"winston-daily-rotate-file": "^4.7.1"
+		"express": "^5.2.1",
+		"mongoose": "^9.3.1",
+		"node": "^25.8.1",
+		"winston": "^3.19.0",
+		"winston-daily-rotate-file": "^5.0.0"
 	},
 	"overrides": {
 		"undici": "^6.23.0"

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
 		"start": "node ratot.js",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
+	"engines": {
+		"node": "^25.8.1"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Ratot-Team/Ratot.git"
 	},
 	"author": "Captain Ratax",
-	"license": "AGPLv3",
+	"license": "AGPL-3.0-or-later",
 	"bugs": {
 		"url": "https://github.com/Ratot-Team/Ratot/issues"
 	},
@@ -22,7 +25,6 @@
 		"dotenv": "^17.3.1",
 		"express": "^5.2.1",
 		"mongoose": "^9.3.1",
-		"node": "^25.8.1",
 		"winston": "^3.19.0",
 		"winston-daily-rotate-file": "^5.0.0"
 	},
@@ -30,4 +32,3 @@
 		"undici": "^6.23.0"
 	}
 }
-

--- a/ratot.js
+++ b/ratot.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config(); //Import the .env library
 
 const { Client, GatewayIntentBits } = require("discord.js"); //Import the Discord.js library
@@ -53,9 +58,9 @@ if (cluster.isWorker) {
 	app.use("/", api);
 	infoLogger.info("API routes are set up and ready to use!");
 
-	app.get("*", function (req, res) {
+	app.get("/{*splat}", function (req, res) {
 		infoLogger.info("Req: " + req + ", Res: " + res);
-		//To Do Later
+		// To Do Later
 	});
 
 	var server = app

--- a/ratot.js
+++ b/ratot.js
@@ -59,8 +59,11 @@ if (cluster.isWorker) {
 	infoLogger.info("API routes are set up and ready to use!");
 
 	app.get("/{*splat}", function (req, res) {
-		infoLogger.info("Req: " + req + ", Res: " + res);
-		// To Do Later
+		infoLogger.info(
+			"Unhandled route hit: " + req.method + " " + req.originalUrl,
+		);
+		// Placeholder handler: return 404 so the request completes
+		return res.status(404).end();
 	});
 
 	var server = app

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 var express = require("express");
 var router = new express.Router();
 

--- a/src/commands/admin/addBotAdmin.js
+++ b/src/commands/admin/addBotAdmin.js
@@ -1,5 +1,10 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config();
-var { ApplicationCommandOptionType, EmbedBuilder } = require("discord.js");
+var { ApplicationCommandOptionType, EmbedBuilder, MessageFlags } = require("discord.js");
 
 const { errorLogger, warnLogger } = require("../../utils/logger");
 const { BotAdmin } = require("../../../models/botAdminsSchema");
@@ -38,20 +43,21 @@ module.exports = {
 			let isBotAdmin;
 			if (!checkAdmin.length || checkAdmin.length === 0) {
 				isBotAdmin =
-					interaction.member.user.id === process.env.RATOT_CREATOR_DISCORD_ID;
+					interaction.member.user.id ===
+					process.env.RATOT_CREATOR_DISCORD_ID;
 			} else {
 				isBotAdmin = true;
 			}
 			if (!isBotAdmin) {
 				return interaction.reply({
 					content: "Only bot admins can use this command!",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			} else {
 				if (userToAdd.id === process.env.RATOT_CURRENT_DISCORD_ID) {
 					return interaction.reply({
 						content: "I cannot be my own administrator",
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					}); //Send a warning message to the user
 				}
 				let verifyUser = await BotAdmin.find({
@@ -66,8 +72,9 @@ module.exports = {
 					});
 					newAdmin.save();
 					interaction.reply({
-						content: "<@" + userToAdd.id + "> is now an administrator!",
-						ephemeral: anonym,
+						content:
+							"<@" + userToAdd.id + "> is now an administrator!",
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
 					});
 					warnLogger.warn(
 						interaction.member.user.username +
@@ -75,7 +82,7 @@ module.exports = {
 							userToAdd.username +
 							" with the id " +
 							userToAdd.id +
-							" as admin!"
+							" as admin!",
 					);
 					try {
 						let currentYear = new Date().getFullYear();
@@ -84,9 +91,11 @@ module.exports = {
 							.setTitle(
 								" Now you are an administrator of the " +
 									process.env.RATOT_CURRENT_NAME +
-									" Bot!"
+									" Bot!",
 							)
-							.setDescription("Here is some commands you can do now:")
+							.setDescription(
+								"Here is some commands you can do now:",
+							)
 							.addFields(
 								{
 									name: "/change-status <number of status> <status>",
@@ -94,13 +103,11 @@ module.exports = {
 								},
 								{
 									name: "/add-bot-admin <@someone>",
-									value:
-										"Add a new administrator to the bot __**(don't do it without the creator permission!)**__",
+									value: "Add a new administrator to the bot __**(don't do it without the creator permission!)**__",
 								},
 								{
 									name: "/remove-bot-admin <@someone>",
-									value:
-										"Remove an administrator of the bot __**(don't do it without the creator permission!)**__",
+									value: "Remove an administrator of the bot __**(don't do it without the creator permission!)**__",
 								},
 								{
 									name: "/list-servers",
@@ -108,13 +115,12 @@ module.exports = {
 								},
 								{
 									name: "/list-channels <optionalServerId>",
-									value:
-										"Lists all the channels from a given server ID or from the server where the message is sent.",
-								}
+									value: "Lists all the channels from a given server ID or from the server where the message is sent.",
+								},
 							)
 							.setTimestamp()
 							.setThumbnail(
-								"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512"
+								"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 							)
 							.setAuthor({
 								name: process.env.RATOT_CURRENT_NAME,
@@ -123,7 +129,10 @@ module.exports = {
 								url: "https://github.com/Ratot-Team/Ratot",
 							})
 							.setFooter({
-								text: "Copyright © 2020-" + currentYear + " by Captain Ratax",
+								text:
+									"Copyright © " +
+									currentYear +
+									" by Captain Ratax",
 								iconURL:
 									"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 							});
@@ -136,31 +145,31 @@ module.exports = {
 									interaction.reply({
 										content:
 											"It wasn't possible to send private message to the user with the admin informations.",
-										ephemeral: true,
-									})
+										flags: MessageFlags.Ephemeral,
+									}),
 								);
 						} catch (err) {
 							errorLogger.error(
 								"An error as occurred when trying to send private message to user. Error:",
-								error
+								error,
 							);
 						}
 					} catch (error) {
 						errorLogger.error(
 							"An error as occurred when trying to send private message to user. Error:",
-							error
+							error,
 						);
 						return interaction.reply({
 							content:
 								"It wasn't possible to send private message to the user with the admin informations.",
-							ephemeral: true,
+							flags: MessageFlags.Ephemeral,
 						});
 					}
 					return;
 				} else {
 					return interaction.reply({
 						content: "That user is already my administrator",
-						ephemeral: anonym,
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
 					});
 				}
 			}
@@ -169,7 +178,7 @@ module.exports = {
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/admin/addBotAdmin.js
+++ b/src/commands/admin/addBotAdmin.js
@@ -151,7 +151,7 @@ module.exports = {
 						} catch (err) {
 							errorLogger.error(
 								"An error as occurred when trying to send private message to user. Error:",
-								error,
+								err,
 							);
 						}
 					} catch (error) {

--- a/src/commands/admin/changeStatusMessage.js
+++ b/src/commands/admin/changeStatusMessage.js
@@ -1,8 +1,14 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config();
 var {
 	ApplicationCommandOptionType,
 	EmbedBuilder,
 	ActivityType,
+	MessageFlags,
 } = require("discord.js");
 
 const { errorLogger, warnLogger } = require("../../utils/logger");
@@ -39,7 +45,8 @@ module.exports = {
 	// botPermissions: [PermissionFlagsBits.ManageMessages],
 	// deleted: true,
 	callback: async (client, interaction) => {
-		const numberOfStatus = interaction.options.getInteger("number-of-status");
+		const numberOfStatus =
+			interaction.options.getInteger("number-of-status");
 		const positionOfStatus = numberOfStatus - 1;
 		const statusMessage = interaction.options.getString("status-message");
 		const anonym = interaction.options.getBoolean("anonym");
@@ -51,21 +58,24 @@ module.exports = {
 			let isBotAdmin;
 			if (!checkAdmin.length || checkAdmin.length === 0) {
 				isBotAdmin =
-					interaction.member.user.id === process.env.RATOT_CREATOR_DISCORD_ID;
+					interaction.member.user.id ===
+					process.env.RATOT_CREATOR_DISCORD_ID;
 			} else {
 				isBotAdmin = true;
 			}
 			if (!isBotAdmin) {
 				return interaction.reply({
 					content: "Only bot admins can use this command!",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			} else {
 				if (numberOfStatus < 1 || numberOfStatus > 4) {
 					let currentYear = new Date().getFullYear();
 					const statusEmbed = new EmbedBuilder()
 						.setColor("#66ccff")
-						.setTitle("You need to specify the type of status you want!")
+						.setTitle(
+							"You need to specify the type of status you want!",
+						)
 						.addFields(
 							{
 								name: "**The list of possible status is:**",
@@ -86,11 +96,11 @@ module.exports = {
 							{
 								name: "4",
 								value: "Competing in",
-							}
+							},
 						)
 						.setTimestamp()
 						.setThumbnail(
-							"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512"
+							"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 						)
 						.setAuthor({
 							name: process.env.RATOT_CURRENT_NAME,
@@ -99,13 +109,16 @@ module.exports = {
 							url: "https://github.com/Ratot-Team/Ratot",
 						})
 						.setFooter({
-							text: "Copyright © 2020-" + currentYear + " by Captain Ratax",
+							text:
+								"Copyright © " +
+								currentYear +
+								" by Captain Ratax",
 							iconURL:
 								"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 						});
 					return interaction.reply({
 						embeds: [statusEmbed],
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					}); //Send a warning message to the user
 				}
 				if (statusMessage.length > 128) {
@@ -114,11 +127,16 @@ module.exports = {
 							"Status can't have more than 128 characters. You wrote a status with " +
 							statusMessage.length +
 							" characters.",
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					});
 				}
 
-				let auxTypesNames = ["PLAYING", "LISTENING", "WATCHING", "COMPETING"];
+				let auxTypesNames = [
+					"PLAYING",
+					"LISTENING",
+					"WATCHING",
+					"COMPETING",
+				];
 				let auxTypes = [
 					ActivityType.Playing,
 					ActivityType.Listening,
@@ -133,12 +151,12 @@ module.exports = {
 				} catch (err) {
 					errorLogger.error(
 						"Error on  command change bot settings. Errors:",
-						err
+						err,
 					);
 					interaction.reply({
 						content:
 							"Something wrong happened when trying to execute that command...",
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					});
 				}
 				warnLogger.warn(
@@ -147,7 +165,7 @@ module.exports = {
 						" to " +
 						auxTypesNames[positionOfStatus] +
 						" " +
-						statusMessage
+						statusMessage,
 				);
 				let checkConfigs = await BotConfigs.find({
 					config: "Status",
@@ -184,7 +202,7 @@ module.exports = {
 						{
 							new: true,
 							useFindAndModify: false,
-						}
+						},
 					);
 				}
 				let changedBotConfigsLog = new BotConfigsLog({
@@ -201,18 +219,18 @@ module.exports = {
 				await changedBotConfigsLog.save();
 				return interaction.reply({
 					content: "Status successfully changed!",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			}
 		} catch (error) {
 			errorLogger.error(
 				"Error on  command change bot settings. Errors:",
-				error
+				error,
 			);
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/admin/listChannels.js
+++ b/src/commands/admin/listChannels.js
@@ -1,8 +1,14 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config();
 var {
 	ApplicationCommandOptionType,
 	EmbedBuilder,
 	ChannelType,
+	MessageFlags,
 } = require("discord.js");
 
 const { errorLogger } = require("../../utils/logger");
@@ -42,7 +48,8 @@ module.exports = {
 			let isBotAdmin;
 			if (!checkAdmin.length || checkAdmin.length === 0) {
 				isBotAdmin =
-					interaction.member.user.id === process.env.RATOT_CREATOR_DISCORD_ID;
+					interaction.member.user.id ===
+					process.env.RATOT_CREATOR_DISCORD_ID;
 			} else {
 				isBotAdmin = true;
 			}
@@ -61,49 +68,67 @@ module.exports = {
 						url: "https://github.com/Ratot-Team/Ratot",
 					})
 					.setFooter({
-						text: "Copyright © 2020-" + currentYear + " by Captain Ratax",
+						text:
+							"Copyright © " + currentYear + " by Captain Ratax",
 						iconURL:
 							"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 					});
 				var embeds = [];
 				if (!serverId) {
-					await interaction.member.guild.channels.cache.forEach((channel) => {
-						i++;
-						if (
-							i % 5 === 0 ||
-							i === interaction.member.guild.channels.cache.size
-						) {
-							tempEmbed.addFields({
-								name: channel.name + " (" + ChannelType[channel.type] + ")",
-								value: channel.id,
-							});
-							embeds[j] = tempEmbed;
-							tempEmbed = new EmbedBuilder()
-								.setColor("#66ccff")
-								.setTitle("Channels List")
-								.setTimestamp()
-								.setAuthor({
-									name: process.env.RATOT_CURRENT_NAME,
-									iconURL:
-										"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
-									url: "https://github.com/Ratot-Team/Ratot",
-								})
-								.setFooter({
-									text: "Copyright © 2020-" + currentYear + " by Captain Ratax",
-									iconURL:
-										"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
+					await interaction.member.guild.channels.cache.forEach(
+						(channel) => {
+							i++;
+							if (
+								i % 5 === 0 ||
+								i ===
+									interaction.member.guild.channels.cache.size
+							) {
+								tempEmbed.addFields({
+									name:
+										channel.name +
+										" (" +
+										ChannelType[channel.type] +
+										")",
+									value: channel.id,
 								});
-							j++;
-						} else {
-							tempEmbed.addFields({
-								name: channel.name + " (" + ChannelType[channel.type] + ")",
-								value: channel.id,
-							});
-						}
-					});
+								embeds[j] = tempEmbed;
+								tempEmbed = new EmbedBuilder()
+									.setColor("#66ccff")
+									.setTitle("Channels List")
+									.setTimestamp()
+									.setAuthor({
+										name: process.env.RATOT_CURRENT_NAME,
+										iconURL:
+											"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
+										url: "https://github.com/Ratot-Team/Ratot",
+									})
+									.setFooter({
+										text:
+											"Copyright © " +
+											currentYear +
+											" by Captain Ratax",
+										iconURL:
+											"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
+									});
+								j++;
+							} else {
+								tempEmbed.addFields({
+									name:
+										channel.name +
+										" (" +
+										ChannelType[channel.type] +
+										")",
+									value: channel.id,
+								});
+							}
+						},
+					);
 
 					if (interaction.member.guild.channels.cache.size <= 5) {
-						return interaction.reply({ embeds, ephemeral: anonym });
+						return interaction.reply({
+							embeds,
+							flags: anonym ? MessageFlags.Ephemeral : undefined,
+						});
 					} else {
 						const timeout = 60000;
 
@@ -113,7 +138,7 @@ module.exports = {
 							interaction.member.user.id,
 							timeout,
 							currentYear,
-							anonym
+							anonym,
 						);
 					}
 				} else {
@@ -124,15 +149,20 @@ module.exports = {
 						}
 					});
 					if (isIdValid) {
-						var channelsCount = await client.guilds.cache.get(serverId).channels
-							.cache.size;
+						var channelsCount =
+							await client.guilds.cache.get(serverId).channels
+								.cache.size;
 						await client.guilds.cache
 							.get(serverId)
 							.channels.cache.forEach((channel) => {
 								i++;
 								if (i % 5 === 0 || i === channelsCount) {
 									tempEmbed.addFields({
-										name: channel.name + " (" + ChannelType[channel.type] + ")",
+										name:
+											channel.name +
+											" (" +
+											ChannelType[channel.type] +
+											")",
 										value: channel.id,
 									});
 									embeds[j] = tempEmbed;
@@ -141,28 +171,40 @@ module.exports = {
 										.setTitle("Channels List")
 										.setTimestamp()
 										.setAuthor({
-											name: process.env.RATOT_CURRENT_NAME,
+											name: process.env
+												.RATOT_CURRENT_NAME,
 											iconURL:
 												"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 											url: "https://github.com/Ratot-Team/Ratot",
 										})
 										.setFooter({
 											text:
-												"Copyright © 2020-" + currentYear + " by Captain Ratax",
+												"Copyright © " +
+												currentYear +
+												" by Captain Ratax",
 											iconURL:
 												"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 										});
 									j++;
 								} else {
 									tempEmbed.addFields({
-										name: channel.name + " (" + ChannelType[channel.type] + ")",
+										name:
+											channel.name +
+											" (" +
+											ChannelType[channel.type] +
+											")",
 										value: channel.id,
 									});
 								}
 							});
 
 						if (channelsCount <= 5) {
-							return interaction.reply({ embeds, ephemeral: anonym });
+							return interaction.reply({
+								embeds,
+								flags: anonym
+									? MessageFlags.Ephemeral
+									: undefined,
+							});
 						} else {
 							const timeout = 60000;
 
@@ -172,20 +214,21 @@ module.exports = {
 								interaction.member.user.id,
 								timeout,
 								currentYear,
-								anonym
+								anonym,
 							);
 						}
 					} else {
 						return interaction.reply({
-							content: "The id provided is not from a valid server.",
-							ephemeral: true,
+							content:
+								"The id provided is not from a valid server.",
+							flags: MessageFlags.Ephemeral,
 						});
 					}
 				}
 			} else {
 				return interaction.reply({
 					content: "Only bot admins can use this command!",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 		} catch (error) {
@@ -193,7 +236,7 @@ module.exports = {
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/admin/listServers.js
+++ b/src/commands/admin/listServers.js
@@ -1,5 +1,14 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config();
-var { EmbedBuilder, ApplicationCommandOptionType } = require("discord.js");
+var {
+	EmbedBuilder,
+	ApplicationCommandOptionType,
+	MessageFlags,
+} = require("discord.js");
 
 const { errorLogger } = require("../../utils/logger");
 const { BotAdmin } = require("../../../models/botAdminsSchema");
@@ -29,7 +38,8 @@ module.exports = {
 			let isBotAdmin;
 			if (!checkAdmin.length || checkAdmin.length === 0) {
 				isBotAdmin =
-					interaction.member.user.id === process.env.RATOT_CREATOR_DISCORD_ID;
+					interaction.member.user.id ===
+					process.env.RATOT_CREATOR_DISCORD_ID;
 			} else {
 				isBotAdmin = true;
 			}
@@ -48,7 +58,8 @@ module.exports = {
 						url: "https://github.com/Ratot-Team/Ratot",
 					})
 					.setFooter({
-						text: "Copyright © 2020-" + currentYear + " by Captain Ratax",
+						text:
+							"Copyright © " + currentYear + " by Captain Ratax",
 						iconURL:
 							"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 					});
@@ -56,7 +67,10 @@ module.exports = {
 				await client.guilds.cache.forEach((guild) => {
 					i++;
 					if (i % 5 === 0 || i === client.guilds.cache.size) {
-						tempEmbed.addFields({ name: guild.name, value: guild.id });
+						tempEmbed.addFields({
+							name: guild.name,
+							value: guild.id,
+						});
 						embeds[j] = tempEmbed;
 						tempEmbed = new EmbedBuilder()
 							.setColor("#66ccff")
@@ -69,18 +83,27 @@ module.exports = {
 								url: "https://github.com/Ratot-Team/Ratot",
 							})
 							.setFooter({
-								text: "Copyright © 2020-" + currentYear + " by Captain Ratax",
+								text:
+									"Copyright © " +
+									currentYear +
+									" by Captain Ratax",
 								iconURL:
 									"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 							});
 						j++;
 					} else {
-						tempEmbed.addFields({ name: guild.name, value: guild.id });
+						tempEmbed.addFields({
+							name: guild.name,
+							value: guild.id,
+						});
 					}
 				});
 
 				if (client.guilds.cache.size <= 5) {
-					return interaction.reply({ embeds, ephemeral: anonym });
+					return interaction.reply({
+						embeds,
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
+					});
 				} else {
 					const timeout = 60000;
 
@@ -90,13 +113,13 @@ module.exports = {
 						interaction.member.user.id,
 						timeout,
 						currentYear,
-						anonym
+						anonym,
 					);
 				}
 			} else {
 				return interaction.reply({
 					content: "Only bot admins can use this command!",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 		} catch (error) {
@@ -104,7 +127,7 @@ module.exports = {
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/admin/removeBotAdmin.js
+++ b/src/commands/admin/removeBotAdmin.js
@@ -1,5 +1,10 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config();
-var { ApplicationCommandOptionType, EmbedBuilder } = require("discord.js");
+var { ApplicationCommandOptionType, MessageFlags } = require("discord.js");
 
 const { errorLogger, warnLogger } = require("../../utils/logger");
 const { BotAdmin } = require("../../../models/botAdminsSchema");
@@ -38,20 +43,21 @@ module.exports = {
 			let isBotAdmin;
 			if (!checkAdmin.length || checkAdmin.length === 0) {
 				isBotAdmin =
-					interaction.member.user.id === process.env.RATOT_CREATOR_DISCORD_ID;
+					interaction.member.user.id ===
+					process.env.RATOT_CREATOR_DISCORD_ID;
 			} else {
 				isBotAdmin = true;
 			}
 			if (!isBotAdmin) {
 				return interaction.reply({
 					content: "Only bot admins can use this command!",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			} else {
 				if (userToRemove.id === process.env.RATOT_CURRENT_DISCORD_ID) {
 					return interaction.reply({
 						content: "I cannot be my own administrator",
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					}); //Send a warning message to the user
 				}
 				let verifyUser = await BotAdmin.find({
@@ -59,8 +65,9 @@ module.exports = {
 				});
 				if (!verifyUser.length || verifyUser.length === 0) {
 					return interaction.reply({
-						content: "<@" + userToRemove.id + "> isn't my administrator",
-						ephemeral: true,
+						content:
+							"<@" + userToRemove.id + "> isn't my administrator",
+						flags: MessageFlags.Ephemeral,
 					});
 				} else {
 					await BotAdmin.deleteMany({
@@ -72,12 +79,14 @@ module.exports = {
 							userToRemove.username +
 							" with the Id " +
 							userToRemove.id +
-							" from admin!"
+							" from admin!",
 					);
 					return interaction.reply({
 						content:
-							"<@" + userToRemove.id + "> is no longer my administrator now",
-						ephemeral: anonym,
+							"<@" +
+							userToRemove.id +
+							"> is no longer my administrator now",
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
 					});
 				}
 			}
@@ -86,7 +95,7 @@ module.exports = {
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/misc/bot-ping.js
+++ b/src/commands/misc/bot-ping.js
@@ -1,4 +1,9 @@
-const { ApplicationCommandOptionType } = require("discord.js");
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
+const { ApplicationCommandOptionType, MessageFlags } = require("discord.js");
 const { errorLogger } = require("../../utils/logger");
 
 module.exports = {
@@ -22,14 +27,14 @@ module.exports = {
 			let botPing = client.ws.ping;
 			interaction.reply({
 				content: "My ping is:" + botPing + "ms",
-				ephemeral: anonym,
+				flags: anonym ? MessageFlags.Ephemeral : undefined,
 			});
 		} catch (error) {
 			errorLogger.error("Error on bot ping command. Errors:", error);
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/misc/help.js
+++ b/src/commands/misc/help.js
@@ -1,5 +1,14 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config();
-const { EmbedBuilder, ApplicationCommandOptionType } = require("discord.js");
+const {
+	EmbedBuilder,
+	ApplicationCommandOptionType,
+	MessageFlags,
+} = require("discord.js");
 
 module.exports = {
 	name: "help",
@@ -36,11 +45,11 @@ module.exports = {
 				{
 					name: "See my code on GitHub!",
 					value: "https://github.com/Ratot-Team/Ratot",
-				}
+				},
 			)
 			.setTimestamp()
 			.setThumbnail(
-				"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512"
+				"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 			)
 			.setAuthor({
 				name: process.env.RATOT_CURRENT_NAME,
@@ -49,13 +58,13 @@ module.exports = {
 				url: "https://github.com/Ratot-Team/Ratot",
 			})
 			.setFooter({
-				text: "Copyright © 2020-" + currentYear + " by Captain Ratax",
+				text: "Copyright © " + currentYear + " by Captain Ratax",
 				iconURL:
 					"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 			}); //Create a personalized embed message
 		interaction.reply({
 			embeds: [helpEmbed],
-			ephemeral: anonym,
+			flags: anonym ? MessageFlags.Ephemeral : undefined,
 		}); //Send that embed message
 	},
 };

--- a/src/commands/misc/hug.js
+++ b/src/commands/misc/hug.js
@@ -1,5 +1,10 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 require("dotenv").config();
-const { ApplicationCommandOptionType } = require("discord.js");
+const { ApplicationCommandOptionType, MessageFlags } = require("discord.js");
 const { errorLogger } = require("../../utils/logger");
 const e = require("express");
 
@@ -29,7 +34,7 @@ module.exports = {
 		if (!interaction.guild) {
 			return interaction.reply({
 				content: "This command can only be used in a server!",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 		const userToHug = interaction.options.getUser("user");
@@ -43,13 +48,13 @@ module.exports = {
 						"I hugged myself as requested by <@" +
 						interaction.member.user.id +
 						">",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			} else if (userToHug.id === interaction.member.user.id) {
 				//If the user mentioned himself
 				interaction.reply({
 					content: "I hugged you!",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			} else {
 				interaction.reply({
@@ -59,7 +64,7 @@ module.exports = {
 						"> as requested by <@" +
 						interaction.member.user.id +
 						">",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			}
 		} catch (error) {
@@ -67,7 +72,7 @@ module.exports = {
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/misc/license.js
+++ b/src/commands/misc/license.js
@@ -11,9 +11,8 @@ const {
 } = require("discord.js");
 
 module.exports = {
-	name: "help-commands",
-	description:
-		"The bot sends the list of all commands and the description of what they do.",
+	name: "license",
+	description: "Shows the bot license information and source code link.",
 	options: [
 		{
 			name: "anonym",
@@ -28,28 +27,30 @@ module.exports = {
 	// deleted: true,
 	callback: (client, interaction) => {
 		//get the current year
-		const currentYear = new Date().getFullYear();
 		const anonym = interaction.options.getBoolean("anonym");
-
-		const helpCommandsEmbed = new EmbedBuilder()
+		const currentYear = new Date().getFullYear();
+		const helpEmbed = new EmbedBuilder()
 			.setColor("#66ccff")
-			.setTitle("Commands List")
+			.setTitle(process.env.RATOT_CURRENT_NAME + " License")
+			.setDescription(
+				"This bot is free software licensed under the GNU Affero General Public License v3.0 or later.",
+			)
 			.addFields(
 				{
-					name: "/ping",
-					value: 'The bot responds with "pong", but to know the bot ping you really have to insist a little bit',
+					name: "License",
+					value: "GNU AGPL v3.0-or-later",
 				},
 				{
-					name: "/prune <number>",
-					value: "The bot deletes a certain number of messages. Only admins can use this command.",
+					name: "Source Code",
+					value: "https://github.com/Ratot-Team/Ratot",
 				},
 				{
-					name: "/hug <@someone>",
-					value: "The bot gives a hug to someone you mention. You can mention yourself don't be shy!",
+					name: "License Details",
+					value: "See the LICENSE file in the GitHub repository for the full license text.",
 				},
 				{
-					name: "/bot-ping",
-					value: "Says the ping value of the bot",
+					name: "Your Rights",
+					value: "You can study, share, and modify this bot under the terms of the AGPL v3 or later.",
 				},
 			)
 			.setTimestamp()
@@ -66,10 +67,10 @@ module.exports = {
 				text: "Copyright © " + currentYear + " by Captain Ratax",
 				iconURL:
 					"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
-			});
+			}); //Create a personalized embed message
 		interaction.reply({
-			embeds: [helpCommandsEmbed],
+			embeds: [helpEmbed],
 			flags: anonym ? MessageFlags.Ephemeral : undefined,
-		});
+		}); //Send that embed message
 	},
 };

--- a/src/commands/misc/ping.js
+++ b/src/commands/misc/ping.js
@@ -1,4 +1,9 @@
-const { ApplicationCommandOptionType } = require("discord.js");
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
+const { ApplicationCommandOptionType, MessageFlags } = require("discord.js");
 const { errorLogger } = require("../../utils/logger");
 var lastPing, pingCounter; //For ping and pong reasons xD
 //lastPing- saves the Id of the person that called the last ping command
@@ -30,15 +35,18 @@ module.exports = {
 				if (pingCounter >= 5) {
 					//If the same person has called the ping command 5 or more times in a row
 					interaction.reply({
-						content: "Oh... Sorry... Right! My ping is " + botPing + "ms",
-						ephemeral: anonym,
+						content:
+							"Oh... Sorry... Right! My ping is " +
+							botPing +
+							"ms",
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
 					});
 					lastPing = interaction.user.id; //Saves who called the ping command
 					pingCounter = 1; //Reset the ping counter
 				} else {
 					interaction.reply({
 						content: "Pong",
-						ephemeral: anonym,
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
 					});
 				}
 			} else {
@@ -46,7 +54,7 @@ module.exports = {
 				pingCounter = 1;
 				interaction.reply({
 					content: "Pong",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			}
 		} catch (error) {
@@ -54,7 +62,7 @@ module.exports = {
 			interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/commands/moderation/prune.js
+++ b/src/commands/moderation/prune.js
@@ -1,5 +1,11 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 var {
 	ApplicationCommandOptionType,
+	MessageFlags,
 	PermissionFlagsBits,
 } = require("discord.js");
 
@@ -34,7 +40,7 @@ module.exports = {
 		if (!interaction.guild) {
 			return interaction.reply({
 				content: "This command can only be used in a server!",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 		try {
@@ -43,7 +49,7 @@ module.exports = {
 
 			if (
 				!interaction.member.permissions.has(
-					PermissionFlagsBits.Administrator
+					PermissionFlagsBits.Administrator,
 				) &&
 				!interaction.member
 					.permissionsIn(interaction.channel)
@@ -52,7 +58,7 @@ module.exports = {
 				return interaction.reply({
 					content:
 						"Only users with the manage messages permission can delete messages!",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 			//Only proceed to the deletion of the messages if the user is an admin
@@ -66,7 +72,7 @@ module.exports = {
 			) {
 				return interaction.reply({
 					content: "I don't have permission to delete messages!",
-					ephemeral: true,
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 
@@ -74,21 +80,21 @@ module.exports = {
 				return interaction.reply({
 					content:
 						"Unfortunately you can only delete a maximum of 99 messages at a time",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			}
 			if (messagesToDelete < 0) {
 				return interaction.reply({
 					content:
 						"Think a little bit of what you asked me to do... Did you really thought you could delete negative messages? Pff humans...",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			}
 			if (messagesToDelete === 0) {
 				return interaction.reply({
 					content:
 						"Nothing deleted! Because you know... 0 is nothing... human...",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				});
 			}
 
@@ -104,10 +110,15 @@ module.exports = {
 				await bulkDeleteMessages(interaction, messagesToDelete, anonym);
 			} else {
 				let timeSpent =
-					currentDate.getTime() - del_command_timeouts[channelId].date;
+					currentDate.getTime() -
+					del_command_timeouts[channelId].date;
 				if (timeSpent > 5000) {
 					del_command_timeouts[channelId].date = currentDate;
-					await bulkDeleteMessages(interaction, messagesToDelete, anonym);
+					await bulkDeleteMessages(
+						interaction,
+						messagesToDelete,
+						anonym,
+					);
 				} else {
 					del_command_timeouts[channelId].date = currentDate;
 					let auxTimeLeft = Math.floor((5000 - timeSpent) / 1000);
@@ -116,7 +127,7 @@ module.exports = {
 							"You need to wait 5 seconds before using the delete command on this channel again. " +
 							auxTimeLeft +
 							" seconds left",
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					});
 				}
 			}
@@ -125,7 +136,7 @@ module.exports = {
 			return interaction.reply({
 				content:
 					"Something wrong happened when trying to execute that command...",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 	},

--- a/src/events/clientReady/01registerCommands.js
+++ b/src/events/clientReady/01registerCommands.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const { errorLogger, warnLogger } = require("../../utils/logger");
 const areCommandsDifferent = require("../../utils/areCommandsDifferent");
 const getApplicationCommands = require("../../utils/getApplicationCommands");

--- a/src/events/clientReady/botInitialization.js
+++ b/src/events/clientReady/botInitialization.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const { infoLogger, errorLogger } = require("../../utils/logger");
 const { BotConfigs } = require("../../../models/botConfigsSchema");
 const { BotAdmin } = require("../../../models/botAdminsSchema");

--- a/src/events/interactionCreate/handleCommands.js
+++ b/src/events/interactionCreate/handleCommands.js
@@ -5,6 +5,7 @@
 
 const { errorLogger } = require("../../utils/logger");
 const getLocalCommands = require("../../utils/getLocalCommands");
+const { MessageFlags } = require("discord.js");
 
 require("dotenv").config();
 

--- a/src/events/interactionCreate/handleCommands.js
+++ b/src/events/interactionCreate/handleCommands.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const { errorLogger } = require("../../utils/logger");
 const getLocalCommands = require("../../utils/getLocalCommands");
 
@@ -10,7 +15,7 @@ module.exports = async (client, interaction) => {
 
 	try {
 		const commandObject = localCommands.find(
-			(cmd) => cmd.name === interaction.commandName
+			(cmd) => cmd.name === interaction.commandName,
 		);
 
 		if (!commandObject) return;
@@ -20,7 +25,7 @@ module.exports = async (client, interaction) => {
 				if (!interaction.member.permissions.has(permission)) {
 					return interaction.reply({
 						content: `You need the permissions to use this command!`,
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					});
 				}
 			}
@@ -33,13 +38,13 @@ module.exports = async (client, interaction) => {
 				if (!bot.permissions.has(permission)) {
 					return interaction.reply({
 						content: `I need permissions to use this command!`,
-						ephemeral: true,
+						flags: MessageFlags.Ephemeral,
 					});
 				}
 			}
 		}
 
-        await commandObject.callback(client, interaction);
+		await commandObject.callback(client, interaction);
 	} catch (error) {
 		errorLogger.error("Error on handleCommands.js. Errors:", error);
 	}

--- a/src/handlers/eventHandler.js
+++ b/src/handlers/eventHandler.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const path = require("path");
 const getAllFiles = require("../utils/getAllFiles");
 const { errorLogger, warnLogger, infoLogger } = require("../utils/logger");

--- a/src/utils/areCommandsDifferent.js
+++ b/src/utils/areCommandsDifferent.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 module.exports = (existingCommand, localCommand) => {
 	const areChoicesDifferent = (existingChoices, localChoices) => {
 		for (const localChoice of localChoices) {

--- a/src/utils/bulkDeleteMessages.js
+++ b/src/utils/bulkDeleteMessages.js
@@ -1,4 +1,10 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const { errorLogger } = require("../utils/logger");
+const { MessageFlags } = require("discord.js");
 var lastDeleteMessageId = 0;
 
 module.exports = async (interaction, messagesToDelete, anonym) => {
@@ -15,7 +21,7 @@ module.exports = async (interaction, messagesToDelete, anonym) => {
 		return interaction.reply({
 			content:
 				"Chill out! Wait a little bit before sending another delete command...",
-			ephemeral: true,
+			flags: MessageFlags.Ephemeral,
 		});
 	}
 
@@ -28,7 +34,7 @@ module.exports = async (interaction, messagesToDelete, anonym) => {
 			return interaction
 				.reply({
 					content: msgsDeleted + " message has been deleted!",
-					ephemeral: anonym,
+					flags: anonym ? MessageFlags.Ephemeral : undefined,
 				})
 				.then((interaction) => {
 					lastDeleteMessageId = interaction.id;
@@ -40,21 +46,23 @@ module.exports = async (interaction, messagesToDelete, anonym) => {
 					.reply({
 						content:
 							"No messages have been deleted, probably because the messages are older than 14 days.",
-						ephemeral: anonym,
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
 					})
 					.then((interaction) => {
 						lastDeleteMessageId = interaction.id;
-						if (!anonym) setTimeout(() => interaction.delete(), 6000); //Delete the success message after 10 seconds
+						if (!anonym)
+							setTimeout(() => interaction.delete(), 6000); //Delete the success message after 10 seconds
 					});
 			} else {
 				return interaction
 					.reply({
 						content: msgsDeleted + " messages have been deleted!",
-						ephemeral: anonym,
+						flags: anonym ? MessageFlags.Ephemeral : undefined,
 					})
 					.then((interaction) => {
 						lastDeleteMessageId = interaction.id;
-						if (!anonym) setTimeout(() => interaction.delete(), 6000); //Delete the success message after 10 seconds
+						if (!anonym)
+							setTimeout(() => interaction.delete(), 6000); //Delete the success message after 10 seconds
 					});
 			}
 		}
@@ -63,7 +71,7 @@ module.exports = async (interaction, messagesToDelete, anonym) => {
 		interaction.reply({
 			content:
 				"Something wrong happened when trying to execute that command...",
-			ephemeral: true,
+			flags: MessageFlags.Ephemeral,
 		});
 	}
 };

--- a/src/utils/custom_discordjs-button-pagination.js
+++ b/src/utils/custom_discordjs-button-pagination.js
@@ -1,7 +1,13 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const {
 	ActionRowBuilder,
 	ButtonBuilder,
 	ComponentType,
+	MessageFlags,
 } = require("discord.js");
 
 const sendPaginatedEmbed = async (
@@ -10,7 +16,7 @@ const sendPaginatedEmbed = async (
 	userId,
 	timeout,
 	currentYear,
-	anonym
+	anonym,
 ) => {
 	let page = 0;
 
@@ -19,12 +25,15 @@ const sendPaginatedEmbed = async (
 			.setCustomId("previous")
 			.setLabel("Previous")
 			.setStyle("Primary"),
-		new ButtonBuilder().setCustomId("next").setLabel("Next").setStyle("Primary")
+		new ButtonBuilder()
+			.setCustomId("next")
+			.setLabel("Next")
+			.setStyle("Primary"),
 	);
 
 	embeds[page].setFooter({
 		text:
-			"Copyright © 2020-" +
+			"Copyright © " +
 			currentYear +
 			" by Captain Ratax" +
 			" | Page 1 of " +
@@ -36,7 +45,7 @@ const sendPaginatedEmbed = async (
 	const message = await originalInteraction.reply({
 		embeds: [embeds[page]],
 		components: [row],
-		ephemeral: anonym,
+		flags: anonym ? MessageFlags.Ephemeral : undefined,
 	});
 
 	const collector = message.createMessageComponentCollector({
@@ -48,7 +57,7 @@ const sendPaginatedEmbed = async (
 		if (interaction.user.id !== userId) {
 			return interaction.reply({
 				content: "You are not allowed to use this button!",
-				ephemeral: true,
+				flags: MessageFlags.Ephemeral,
 			});
 		}
 
@@ -61,7 +70,7 @@ const sendPaginatedEmbed = async (
 		}
 		embeds[page].setFooter({
 			text:
-				"Copyright © 2020-" +
+				"Copyright © " +
 				currentYear +
 				" by Captain Ratax" +
 				" | Page " +

--- a/src/utils/custom_discordjs-button-pagination.js
+++ b/src/utils/custom_discordjs-button-pagination.js
@@ -6,6 +6,7 @@
 const {
 	ActionRowBuilder,
 	ButtonBuilder,
+	ButtonStyle,
 	ComponentType,
 	MessageFlags,
 } = require("discord.js");
@@ -24,11 +25,11 @@ const sendPaginatedEmbed = async (
 		new ButtonBuilder()
 			.setCustomId("previous")
 			.setLabel("Previous")
-			.setStyle("Primary"),
+			.setStyle(ButtonStyle.Primary),
 		new ButtonBuilder()
 			.setCustomId("next")
 			.setLabel("Next")
-			.setStyle("Primary"),
+			.setStyle(ButtonStyle.Primary),
 	);
 
 	embeds[page].setFooter({
@@ -42,11 +43,13 @@ const sendPaginatedEmbed = async (
 			"https://cdn.discordapp.com/avatars/759404636888498186/7767a8b3aae66dc5198ca89f7fc16173.png?size=512",
 	});
 
-	const message = await originalInteraction.reply({
+	await originalInteraction.reply({
 		embeds: [embeds[page]],
 		components: [row],
 		flags: anonym ? MessageFlags.Ephemeral : undefined,
 	});
+
+	const message = await originalInteraction.fetchReply();
 
 	const collector = message.createMessageComponentCollector({
 		componentType: ComponentType.Button,
@@ -68,6 +71,7 @@ const sendPaginatedEmbed = async (
 		} else if (interaction.customId === "next") {
 			page = page + 1 < embeds.length ? ++page : 0;
 		}
+
 		embeds[page].setFooter({
 			text:
 				"Copyright © " +
@@ -87,8 +91,14 @@ const sendPaginatedEmbed = async (
 		});
 	});
 
-	collector.on("end", () => {
-		message.edit({ components: [] });
+	collector.on("end", async () => {
+		try {
+			await originalInteraction.editReply({
+				components: [],
+			});
+		} catch (error) {
+			// Ignore errors if the message no longer exists or cannot be edited
+		}
 	});
 };
 

--- a/src/utils/getAllFiles.js
+++ b/src/utils/getAllFiles.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const fs = require("fs");
 const path = require("path");
 

--- a/src/utils/getApplicationCommands.js
+++ b/src/utils/getApplicationCommands.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 module.exports = async (client, guildId) => {
     let applicationCommands;
 

--- a/src/utils/getLocalCommands.js
+++ b/src/utils/getLocalCommands.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const path = require("path");
 const getAllFiles = require("../utils/getAllFiles");
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,3 +1,8 @@
+// Ratot - Ratot is a Discord bot made to help you administrate your server and have some fun.
+// Copyright (C) 2026 CaptainRatax
+// Licensed under the GNU Affero General Public License v3.0 or later
+// See the LICENSE file for details.
+
 const { format, createLogger, transports } = require("winston");
 const { timestamp, combine, printf } = format;
 require("winston-daily-rotate-file");


### PR DESCRIPTION
Replaces the GNU General Public License v3 with the GNU Affero General Public License v3.0 or later. This ensures server-side usage also distributes source code.

Adds a new `COPYRIGHT` file and updates the `LICENSE` file content. Updates `package.json` and `README.md` to reflect the new license. Adds license headers to all source code files for clarity.

Added a `/license` command to display license information.

Migrates Discord.js `ephemeral` replies to use `MessageFlags.Ephemeral` for API compatibility. Dynamically sets copyright years in bot embed footers. Bumps several package dependencies.